### PR TITLE
[SceneKitReel] Add "iOS" constant to Debug|iPhone and Release|iPhone configs

### DIFF
--- a/SceneKitReel/SceneKitReeliOS/SceneKitReeliOS.csproj
+++ b/SceneKitReel/SceneKitReeliOS/SceneKitReeliOS.csproj
@@ -44,7 +44,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\iPhone\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>DEBUG;iOS;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -63,6 +63,7 @@
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
+    <DefineConstants>iOS;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>


### PR DESCRIPTION
When `iOS` constant was not present, this line failed to be enabled
https://github.com/xamarin/mac-ios-samples/blob/master/SceneKitReel/SceneKitReelShared/GameViewController.cs#L1067

and the [test failed with error](http://xqa.blob.core.windows.net/gist/log-0de9590709314ab9b89494ad5f9fbd4b.txt)

```
/Users/manish/code/mac-ios-samples/SceneKitReel/SceneKitReelShared/GameViewController.cs(1072,4,1072,7): error CS0103: The name 'p3d' does not exist in the current context
/Users/manish/code/mac-ios-samples/SceneKitReel/SceneKitReelShared/GameViewController.cs(1081,26,1081,29): error CS0103: The name 'p3d' does not exist in the current context
```


![screenshot](http://xqa.blob.core.windows.net/gist/014-Test-Failed.png-f5297b656408458ba7e698c550406028.png)