### PR TITLE
Sample cleanup (including NSUrlSessionHandler settings)

### DIFF
--- a/Adventure/Adventure.sln
+++ b/Adventure/Adventure.sln
@@ -13,35 +13,28 @@ Global
 		Release|iPhoneSimulator = Release|iPhoneSimulator
 		Debug|iPhone = Debug|iPhone
 		Release|iPhone = Release|iPhone
-		Ad-Hoc|iPhone = Ad-Hoc|iPhone
-		AppStore|iPhone = AppStore|iPhone
-		Debug|Any CPU = Debug|Any CPU
-		Default|Any CPU = Default|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Ad-Hoc|iPhone.ActiveCfg = Release|Any CPU
-		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.AppStore|iPhone.ActiveCfg = AppStore|Any CPU
-		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Default|Any CPU.ActiveCfg = Debug|Any CPU
-		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Default|Any CPU.Build.0 = Debug|Any CPU
 		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Ad-Hoc|iPhone.ActiveCfg = Ad-Hoc|iPhone
-		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Ad-Hoc|iPhone.Build.0 = Ad-Hoc|iPhone
-		{56AF2239-6869-4FBF-AD56-23A71859AB63}.AppStore|iPhone.ActiveCfg = AppStore|iPhone
-		{56AF2239-6869-4FBF-AD56-23A71859AB63}.AppStore|iPhone.Build.0 = AppStore|iPhone
-		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}.Release|iPhone.Build.0 = Release|Any CPU
 		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Debug|iPhone.Build.0 = Debug|iPhone
 		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
 		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
-		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Default|Any CPU.ActiveCfg = Debug|Any CPU
 		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Release|iPhone.ActiveCfg = Release|iPhone
 		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Release|iPhone.Build.0 = Release|iPhone
 		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
 		{56AF2239-6869-4FBF-AD56-23A71859AB63}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		Policies = $0
+		$0.DotNetNamingPolicy = $1
+		$1.DirectoryNamespaceAssociation = PrefixedHierarchical
 	EndGlobalSection
 EndGlobal

--- a/Adventure/AdventureMac/AdventureMac.csproj
+++ b/Adventure/AdventureMac/AdventureMac.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{53E03C26-A7AD-46F2-88DB-9863D5FC0C20}</ProjectGuid>
@@ -11,24 +11,6 @@
     <AssemblyName>AdventureMac</AssemblyName>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <UseSGen>false</UseSGen>
-    <IncludeMonoRuntime>false</IncludeMonoRuntime>
-    <EnablePackageSigning>false</EnablePackageSigning>
-    <CodeSigningKey>Mac Developer</CodeSigningKey>
-    <EnableCodeSigning>false</EnableCodeSigning>
-    <CreatePackage>false</CreatePackage>
-    <UseRefCounting>false</UseRefCounting>
-    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -41,29 +23,33 @@
     <UseSGen>false</UseSGen>
     <IncludeMonoRuntime>true</IncludeMonoRuntime>
     <EnablePackageSigning>false</EnablePackageSigning>
-    <CodeSigningKey>Developer ID Application</CodeSigningKey>
+    <CodeSigningKey>Mac Developer</CodeSigningKey>
     <EnableCodeSigning>true</EnableCodeSigning>
     <CreatePackage>true</CreatePackage>
     <UseRefCounting>false</UseRefCounting>
     <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
+    <AOTMode>None</AOTMode>
+    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>false</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\AppStore</OutputPath>
+    <OutputPath>bin\Debug</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <LinkMode>SdkOnly</LinkMode>
     <UseSGen>false</UseSGen>
     <IncludeMonoRuntime>true</IncludeMonoRuntime>
-    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
-    <CreatePackage>true</CreatePackage>
-    <CodeSigningKey>3rd Party Mac Developer Application</CodeSigningKey>
+    <EnablePackageSigning>false</EnablePackageSigning>
+    <CodeSigningKey>Mac Developer</CodeSigningKey>
     <EnableCodeSigning>true</EnableCodeSigning>
-    <EnablePackageSigning>true</EnablePackageSigning>
+    <CreatePackage>true</CreatePackage>
     <UseRefCounting>false</UseRefCounting>
     <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
+    <AOTMode>None</AOTMode>
+    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Adventure/AdventureMac/AdventureMac.csproj
+++ b/Adventure/AdventureMac/AdventureMac.csproj
@@ -23,7 +23,7 @@
     <UseSGen>false</UseSGen>
     <IncludeMonoRuntime>true</IncludeMonoRuntime>
     <EnablePackageSigning>false</EnablePackageSigning>
-    <CodeSigningKey>Mac Developer</CodeSigningKey>
+    <CodeSigningKey>3rd Party Mac Developer Application</CodeSigningKey>
     <EnableCodeSigning>true</EnableCodeSigning>
     <CreatePackage>true</CreatePackage>
     <UseRefCounting>false</UseRefCounting>

--- a/Adventure/AdventureMac/AdventureMac.csproj
+++ b/Adventure/AdventureMac/AdventureMac.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -28,6 +28,7 @@
     <EnableCodeSigning>false</EnableCodeSigning>
     <CreatePackage>false</CreatePackage>
     <UseRefCounting>false</UseRefCounting>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -44,6 +45,7 @@
     <EnableCodeSigning>true</EnableCodeSigning>
     <CreatePackage>true</CreatePackage>
     <UseRefCounting>false</UseRefCounting>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -61,6 +63,7 @@
     <EnableCodeSigning>true</EnableCodeSigning>
     <EnablePackageSigning>true</EnablePackageSigning>
     <UseRefCounting>false</UseRefCounting>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Adventure/AdventureMac/Info.plist
+++ b/Adventure/AdventureMac/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>AdventureMac</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.your-company.AdventureMac</string>
+	<string>com.xamarin.AdventureMac</string>
 	<key>CFBundleName</key>
 	<string>AdventureMac</string>
 	<key>CFBundleVersion</key>

--- a/Adventure/AdventureiOS/AdventureiOS.csproj
+++ b/Adventure/AdventureiOS/AdventureiOS.csproj
@@ -18,14 +18,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchProfiling>true</MtouchProfiling>
-    <AssemblyName>AdventureiOS</AssemblyName>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchI18n></MtouchI18n>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
@@ -37,11 +35,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <AssemblyName>AdventureiOS</AssemblyName>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
@@ -58,7 +55,6 @@
     <MtouchProfiling>true</MtouchProfiling>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
-    <AssemblyName>AdventureiOS</AssemblyName>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
@@ -72,46 +68,7 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <AssemblyName>AdventureiOS</AssemblyName>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\iPhone\Ad-Hoc</OutputPath>
-    <DefineConstants>__MOBILE__;__IOS__;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <IpaIncludeArtwork>true</IpaIncludeArtwork>
-    <CodesignKey>iPhone Distribution</CodesignKey>
-    <CodesignProvision>Automatic:AdHoc</CodesignProvision>
-    <BuildIpa>true</BuildIpa>
-    <AssemblyName>AdventureiOS</AssemblyName>
-    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\iPhone\AppStore</OutputPath>
-    <DefineConstants>__MOBILE__;__IOS__;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <CodesignProvision>Automatic:AppStore</CodesignProvision>
-    <CodesignKey>iPhone Distribution</CodesignKey>
-    <AssemblyName>AdventureiOS</AssemblyName>
-    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <WarningLevel>4</WarningLevel>
-    <AssemblyName>Adventure</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Adventure/AdventureiOS/AdventureiOS.csproj
+++ b/Adventure/AdventureiOS/AdventureiOS.csproj
@@ -67,7 +67,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>iPhone Distribution</CodesignKey>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>

--- a/Adventure/AdventureiOS/AdventureiOS.csproj
+++ b/Adventure/AdventureiOS/AdventureiOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -26,8 +26,8 @@
     <MtouchProfiling>true</MtouchProfiling>
     <AssemblyName>AdventureiOS</AssemblyName>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
-    <MtouchI18n>
-    </MtouchI18n>
+    <MtouchI18n></MtouchI18n>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>full</DebugType>
@@ -42,6 +42,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <AssemblyName>AdventureiOS</AssemblyName>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -58,6 +59,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <AssemblyName>AdventureiOS</AssemblyName>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>full</DebugType>
@@ -71,6 +73,7 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <AssemblyName>AdventureiOS</AssemblyName>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>full</DebugType>
@@ -87,6 +90,7 @@
     <CodesignProvision>Automatic:AdHoc</CodesignProvision>
     <BuildIpa>true</BuildIpa>
     <AssemblyName>AdventureiOS</AssemblyName>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
     <DebugType>full</DebugType>
@@ -101,6 +105,7 @@
     <CodesignProvision>Automatic:AppStore</CodesignProvision>
     <CodesignKey>iPhone Distribution</CodesignKey>
     <AssemblyName>AdventureiOS</AssemblyName>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>

--- a/Adventure/AdventureiOS/Info.plist
+++ b/Adventure/AdventureiOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>Adventure</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.your-company.Adventure</string>
+	<string>com.xamarin.Adventure</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
@@ -43,5 +43,7 @@
 	<string>Assets/Assets - iOS.xcassets/AppIcon.appiconset</string>
 	<key>XSLaunchImageAssets</key>
 	<string>Assets/Assets - iOS.xcassets/LaunchImage.launchimage</string>
+	<key>CFBundleName</key>
+	<string>Adventure</string>
 </dict>
 </plist>

--- a/AgentsCatalog/AgentsCatalog.Mac/AgentsCatalog.Mac.csproj
+++ b/AgentsCatalog/AgentsCatalog.Mac/AgentsCatalog.Mac.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -32,6 +32,7 @@
     <PackageSigningKey>Developer ID Installer</PackageSigningKey>
     <XamMacArch>x86_64</XamMacArch>
     <AOTMode>None</AOTMode>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -51,6 +52,7 @@
     <DefineConstants>TARGET_OS_MAC;</DefineConstants>
     <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
     <AOTMode>None</AOTMode>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/AgentsCatalog/AgentsCatalog.Mac/Info.plist
+++ b/AgentsCatalog/AgentsCatalog.Mac/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.your-company.AgentsCatalog</string>
+	<string>com.xamarin.AgentsCatalog</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/AgentsCatalog/AgentsCatalog.iOS/AgentsCatalog.iOS.csproj
+++ b/AgentsCatalog/AgentsCatalog.iOS/AgentsCatalog.iOS.csproj
@@ -33,7 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>iPhone Distribution</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <DefineConstants>TARGET_OS_IOS;</DefineConstants>

--- a/AgentsCatalog/AgentsCatalog.iOS/AgentsCatalog.iOS.csproj
+++ b/AgentsCatalog/AgentsCatalog.iOS/AgentsCatalog.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -27,6 +27,7 @@
     <MtouchLink>None</MtouchLink>
     <MtouchArch>i386</MtouchArch>
     <AssemblyName>AgentsCatalogiOS</AssemblyName>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <Optimize>true</Optimize>
@@ -41,6 +42,7 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <DefineConstants>TARGET_OS_IOS;</DefineConstants>
     <AssemblyName>AgentsCatalog.iOS</AssemblyName>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <Optimize>true</Optimize>
@@ -55,6 +57,7 @@
     <MtouchArch>i386</MtouchArch>
     <DefineConstants>TARGET_OS_IOS;</DefineConstants>
     <AssemblyName>AgentsCatalogiOS</AssemblyName>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -73,9 +76,9 @@
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <IpaPackageName>
-    </IpaPackageName>
+    <IpaPackageName></IpaPackageName>
     <AssemblyName>AgentsCatalogiOS</AssemblyName>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/AgentsCatalog/AgentsCatalog.iOS/AgentsCatalog.iOS.csproj
+++ b/AgentsCatalog/AgentsCatalog.iOS/AgentsCatalog.iOS.csproj
@@ -22,10 +22,8 @@
     <MtouchDebug>true</MtouchDebug>
     <MtouchFastDev>true</MtouchFastDev>
     <MtouchProfiling>true</MtouchProfiling>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchLink>None</MtouchLink>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <AssemblyName>AgentsCatalogiOS</AssemblyName>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
@@ -36,8 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <DefineConstants>TARGET_OS_IOS;</DefineConstants>
@@ -51,10 +47,8 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchLink>None</MtouchLink>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <DefineConstants>TARGET_OS_IOS;</DefineConstants>
     <AssemblyName>AgentsCatalogiOS</AssemblyName>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
@@ -72,8 +66,6 @@
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <IpaPackageName></IpaPackageName>

--- a/ExceptionMarshaling/Mac/ExceptionMarshaling.Mac.csproj
+++ b/ExceptionMarshaling/Mac/ExceptionMarshaling.Mac.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -33,6 +33,7 @@
     <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
     <MonoBundlingExtraArgs>--disable-lldb-attach=true</MonoBundlingExtraArgs>
     <TlsProvider>Default</TlsProvider>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <Optimize>true</Optimize>
@@ -52,6 +53,7 @@
     <MonoBundlingExtraArgs>--disable-lldb-attach=true</MonoBundlingExtraArgs>
     <TlsProvider>Default</TlsProvider>
     <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/ExceptionMarshaling/Mac/ExceptionMarshaling.Mac.csproj
+++ b/ExceptionMarshaling/Mac/ExceptionMarshaling.Mac.csproj
@@ -34,6 +34,7 @@
     <MonoBundlingExtraArgs>--disable-lldb-attach=true</MonoBundlingExtraArgs>
     <TlsProvider>Default</TlsProvider>
     <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
+    <AOTMode>None</AOTMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <Optimize>true</Optimize>
@@ -41,8 +42,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <EnableCodeSigning>false</EnableCodeSigning>
-    <CodeSigningKey>Developer ID Application</CodeSigningKey>
+    <EnableCodeSigning>true</EnableCodeSigning>
+    <CodeSigningKey>Mac Developer</CodeSigningKey>
     <CreatePackage>false</CreatePackage>
     <EnablePackageSigning>false</EnablePackageSigning>
     <IncludeMonoRuntime>true</IncludeMonoRuntime>
@@ -54,6 +55,7 @@
     <TlsProvider>Default</TlsProvider>
     <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
     <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
+    <AOTMode>None</AOTMode>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/ExceptionMarshaling/Mac/ExceptionMarshaling.Mac.csproj
+++ b/ExceptionMarshaling/Mac/ExceptionMarshaling.Mac.csproj
@@ -43,7 +43,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <EnableCodeSigning>true</EnableCodeSigning>
-    <CodeSigningKey>Mac Developer</CodeSigningKey>
+    <CodeSigningKey>3rd Party Mac Developer Application</CodeSigningKey>
     <CreatePackage>false</CreatePackage>
     <EnablePackageSigning>false</EnablePackageSigning>
     <IncludeMonoRuntime>true</IncludeMonoRuntime>
@@ -56,6 +56,7 @@
     <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
     <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
     <AOTMode>None</AOTMode>
+    <CodeSignProvision>Automatic</CodeSignProvision>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/ExceptionMarshaling/iOS/ExceptionMarshaling.IOS.csproj
+++ b/ExceptionMarshaling/iOS/ExceptionMarshaling.IOS.csproj
@@ -36,7 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>iPhone Distribution</CodesignKey>
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>

--- a/ExceptionMarshaling/iOS/ExceptionMarshaling.IOS.csproj
+++ b/ExceptionMarshaling/iOS/ExceptionMarshaling.IOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -27,7 +27,7 @@
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchLink>None</MtouchLink>
     <MtouchArch>i386</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
     <MtouchExtraArgs></MtouchExtraArgs>
@@ -45,7 +45,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
@@ -60,7 +60,7 @@
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchLink>None</MtouchLink>
     <MtouchArch>i386</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
@@ -84,7 +84,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>

--- a/ExceptionMarshaling/iOS/ExceptionMarshaling.IOS.csproj
+++ b/ExceptionMarshaling/iOS/ExceptionMarshaling.IOS.csproj
@@ -23,10 +23,8 @@
     <MtouchDebug>true</MtouchDebug>
     <MtouchFastDev>true</MtouchFastDev>
     <MtouchProfiling>true</MtouchProfiling>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchLink>None</MtouchLink>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
@@ -39,8 +37,6 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
@@ -56,10 +52,8 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchLink>None</MtouchLink>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
@@ -78,8 +72,6 @@
     <MtouchDebug>true</MtouchDebug>
     <MtouchFastDev>true</MtouchFastDev>
     <MtouchProfiling>true</MtouchProfiling>
-    <MtouchUseSGen>true</MtouchUseSGen>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>

--- a/MetalKitEssentials/MetalKitEssentials.Mac/Info.plist
+++ b/MetalKitEssentials/MetalKitEssentials.Mac/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.your-company.MetalKitEssentials.Mac</string>
+	<string>com.xamarin.MetalKitEssentials.Mac</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/MetalKitEssentials/MetalKitEssentials.Mac/MetalKitEssentials.Mac.csproj
+++ b/MetalKitEssentials/MetalKitEssentials.Mac/MetalKitEssentials.Mac.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -30,6 +30,7 @@
     <CreatePackage>false</CreatePackage>
     <Profiling>false</Profiling>
     <AOTMode>None</AOTMode>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -49,6 +50,7 @@
     <DefineConstants>MAC;</DefineConstants>
     <AOTMode>None</AOTMode>
     <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/MetalKitEssentials/MetalKitEssentials.Mac/MetalKitEssentials.Mac.csproj
+++ b/MetalKitEssentials/MetalKitEssentials.Mac/MetalKitEssentials.Mac.csproj
@@ -31,6 +31,7 @@
     <Profiling>false</Profiling>
     <AOTMode>None</AOTMode>
     <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
+    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/MetalKitEssentials/MetalKitEssentials.iOS/Info.plist
+++ b/MetalKitEssentials/MetalKitEssentials.iOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>MetalKitEssentials</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.example.apple-splecode.metalkitessentials</string>
+	<string>com.xamarin.metalkitessentials</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/MetalKitEssentials/MetalKitEssentials.iOS/MetalKitEssentials.iOS.csproj
+++ b/MetalKitEssentials/MetalKitEssentials.iOS/MetalKitEssentials.iOS.csproj
@@ -2,29 +2,13 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">iPhone</Platform>
     <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{EADF2F60-DC7B-4D90-A113-E43E061AAB78}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>MetalKitEssentials</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>MetalKitEssentials</AssemblyName>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
-    <DefineConstants>DEBUG;IOS;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
-    <MtouchLink>None</MtouchLink>
-    <MtouchDebug>true</MtouchDebug>
-    <MtouchProfiling>true</MtouchProfiling>
-    <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <Optimize>true</Optimize>
@@ -37,18 +21,6 @@
     <DefineConstants>IOS;</DefineConstants>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <MtouchArch>i386</MtouchArch>
-    <ConsolePause>false</ConsolePause>
-    <MtouchLink>None</MtouchLink>
-    <DefineConstants>IOS;</DefineConstants>
-    <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -58,11 +30,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>ARMv7, ARMv7s, ARM64</MtouchArch>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchProfiling>true</MtouchProfiling>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchI18n></MtouchI18n>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>

--- a/MetalKitEssentials/MetalKitEssentials.iOS/MetalKitEssentials.iOS.csproj
+++ b/MetalKitEssentials/MetalKitEssentials.iOS/MetalKitEssentials.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -24,6 +24,7 @@
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <Optimize>true</Optimize>
@@ -34,6 +35,7 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <DefineConstants>IOS;</DefineConstants>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <Optimize>true</Optimize>
@@ -45,6 +47,7 @@
     <MtouchLink>None</MtouchLink>
     <DefineConstants>IOS;</DefineConstants>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -60,8 +63,8 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
-    <MtouchI18n>
-    </MtouchI18n>
+    <MtouchI18n></MtouchI18n>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Main.storyboard" />

--- a/MetalKitEssentials/MetalKitEssentials.iOS/MetalKitEssentials.iOS.csproj
+++ b/MetalKitEssentials/MetalKitEssentials.iOS/MetalKitEssentials.iOS.csproj
@@ -17,7 +17,7 @@
     <WarningLevel>4</WarningLevel>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>iPhone Distribution</CodesignKey>
     <DefineConstants>IOS;</DefineConstants>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>

--- a/MetalKitEssentials/MetalKitEssentials.sln
+++ b/MetalKitEssentials/MetalKitEssentials.sln
@@ -9,27 +9,17 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetalKitEssentials.Mac", "M
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|iPhoneSimulator = Debug|iPhoneSimulator
 		Release|iPhone = Release|iPhone
-		Release|iPhoneSimulator = Release|iPhoneSimulator
 		Debug|iPhone = Debug|iPhone
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Release|iPhone.Build.0 = Release|Any CPU
-		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{EADF2F60-DC7B-4D90-A113-E43E061AAB78}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{EADF2F60-DC7B-4D90-A113-E43E061AAB78}.Debug|iPhone.Build.0 = Debug|iPhone
-		{EADF2F60-DC7B-4D90-A113-E43E061AAB78}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
-		{EADF2F60-DC7B-4D90-A113-E43E061AAB78}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
 		{EADF2F60-DC7B-4D90-A113-E43E061AAB78}.Release|iPhone.ActiveCfg = Release|iPhone
 		{EADF2F60-DC7B-4D90-A113-E43E061AAB78}.Release|iPhone.Build.0 = Release|iPhone
-		{EADF2F60-DC7B-4D90-A113-E43E061AAB78}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
-		{EADF2F60-DC7B-4D90-A113-E43E061AAB78}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
 	EndGlobalSection
 EndGlobal

--- a/Objective-C/Selectors/ObjCSelectors.sln
+++ b/Objective-C/Selectors/ObjCSelectors.sln
@@ -9,14 +9,8 @@ Global
 		Release|iPhoneSimulator = Release|iPhoneSimulator
 		Debug|iPhone = Debug|iPhone
 		Release|iPhone = Release|iPhone
-		Ad-Hoc|iPhone = Ad-Hoc|iPhone
-		AppStore|iPhone = AppStore|iPhone
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{114358A7-7CFE-47B2-945B-E5864C2F99E7}.Ad-Hoc|iPhone.ActiveCfg = Ad-Hoc|iPhone
-		{114358A7-7CFE-47B2-945B-E5864C2F99E7}.Ad-Hoc|iPhone.Build.0 = Ad-Hoc|iPhone
-		{114358A7-7CFE-47B2-945B-E5864C2F99E7}.AppStore|iPhone.ActiveCfg = AppStore|iPhone
-		{114358A7-7CFE-47B2-945B-E5864C2F99E7}.AppStore|iPhone.Build.0 = AppStore|iPhone
 		{114358A7-7CFE-47B2-945B-E5864C2F99E7}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{114358A7-7CFE-47B2-945B-E5864C2F99E7}.Debug|iPhone.Build.0 = Debug|iPhone
 		{114358A7-7CFE-47B2-945B-E5864C2F99E7}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator

--- a/Objective-C/Selectors/ObjCSelectors/Info.plist
+++ b/Objective-C/Selectors/ObjCSelectors/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -34,5 +34,7 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<key>CFBundleName</key>
+	<string>ObjCSelectors</string>
 </dict>
 </plist>

--- a/Objective-C/Selectors/ObjCSelectors/Info.plist
+++ b/Objective-C/Selectors/ObjCSelectors/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>ObjCSelectors</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.your-company.ObjCSelectors</string>
+	<string>com.xamarin.ObjCSelectors</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/Objective-C/Selectors/ObjCSelectors/ObjCSelectors.csproj
+++ b/Objective-C/Selectors/ObjCSelectors/ObjCSelectors.csproj
@@ -19,7 +19,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchDebug>true</MtouchDebug>
@@ -34,7 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
@@ -66,34 +66,6 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\iPhone\Ad-Hoc</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <IpaIncludeArtwork>true</IpaIncludeArtwork>
-    <CodesignKey>iPhone Distribution</CodesignKey>
-    <CodesignProvision>Automatic:AdHoc</CodesignProvision>
-    <BuildIpa>true</BuildIpa>
-    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\iPhone\AppStore</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <CodesignProvision>Automatic:AppStore</CodesignProvision>
-    <CodesignKey>iPhone Distribution</CodesignKey>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>

--- a/Objective-C/Selectors/ObjCSelectors/ObjCSelectors.csproj
+++ b/Objective-C/Selectors/ObjCSelectors/ObjCSelectors.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -25,6 +25,7 @@
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchProfiling>true</MtouchProfiling>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>full</DebugType>
@@ -37,6 +38,7 @@
     <MtouchLink>None</MtouchLink>
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,6 +54,7 @@
     <MtouchProfiling>true</MtouchProfiling>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>full</DebugType>
@@ -63,6 +66,7 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>full</DebugType>
@@ -77,6 +81,7 @@
     <CodesignKey>iPhone Distribution</CodesignKey>
     <CodesignProvision>Automatic:AdHoc</CodesignProvision>
     <BuildIpa>true</BuildIpa>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
     <DebugType>full</DebugType>
@@ -89,6 +94,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignProvision>Automatic:AppStore</CodesignProvision>
     <CodesignKey>iPhone Distribution</CodesignKey>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Objective-C/Selectors/ObjCSelectors/ObjCSelectors.csproj
+++ b/Objective-C/Selectors/ObjCSelectors/ObjCSelectors.csproj
@@ -65,7 +65,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>iPhone Distribution</CodesignKey>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>

--- a/SceneKitReel/SceneKitReel.sln
+++ b/SceneKitReel/SceneKitReel.sln
@@ -11,47 +11,24 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		AppStore|Any CPU = AppStore|Any CPU
 		Debug|iPhoneSimulator = Debug|iPhoneSimulator
 		Release|iPhoneSimulator = Release|iPhoneSimulator
 		Debug|iPhone = Debug|iPhone
 		Release|iPhone = Release|iPhone
-		Ad-Hoc|iPhone = Ad-Hoc|iPhone
-		AppStore|iPhone = AppStore|iPhone
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
-		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
-		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.AppStore|Any CPU.ActiveCfg = AppStore|Any CPU
-		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.AppStore|Any CPU.Build.0 = AppStore|Any CPU
-		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.AppStore|iPhone.ActiveCfg = AppStore|Any CPU
-		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.AppStore|iPhone.Build.0 = AppStore|Any CPU
-		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Release|iPhone.Build.0 = Release|Any CPU
 		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{CFDC4C7E-92F4-4BB6-A311-0317BA4586AB}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Ad-Hoc|iPhone.ActiveCfg = Ad-Hoc|iPhone
-		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Ad-Hoc|iPhone.Build.0 = Ad-Hoc|iPhone
-		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.AppStore|Any CPU.ActiveCfg = AppStore|iPhone
-		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.AppStore|Any CPU.Build.0 = AppStore|iPhone
-		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.AppStore|iPhone.ActiveCfg = AppStore|iPhone
-		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.AppStore|iPhone.Build.0 = AppStore|iPhone
-		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
-		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
 		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Debug|iPhone.Build.0 = Debug|iPhone
 		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
 		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
-		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Release|Any CPU.ActiveCfg = Release|iPhoneSimulator
-		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Release|Any CPU.Build.0 = Release|iPhoneSimulator
 		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Release|iPhone.ActiveCfg = Release|iPhone
 		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Release|iPhone.Build.0 = Release|iPhone
 		{D9BB17B9-272B-47D4-BBBA-C189238E9BCD}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
@@ -61,7 +38,5 @@ Global
 		StartupItem = SceneKitReelMac\SceneKitReelMac.csproj
 		Policies = $0
 		$0.DotNetNamingPolicy = $1
-		$1.DirectoryNamespaceAssociation = None
-		$1.ResourceNamePolicy = FileFormatDefault
 	EndGlobalSection
 EndGlobal

--- a/SceneKitReel/SceneKitReelMac/Info.plist
+++ b/SceneKitReel/SceneKitReelMac/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>SceneKitReel</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.your-company.SceneKitReel</string>
+	<string>com.xamarin.SceneKitReel</string>
 	<key>CFBundleName</key>
 	<string>SceneKitReel</string>
 	<key>CFBundleVersion</key>

--- a/SceneKitReel/SceneKitReelMac/SceneKitReelMac.csproj
+++ b/SceneKitReel/SceneKitReelMac/SceneKitReelMac.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -31,6 +31,7 @@
     <UseRefCounting>false</UseRefCounting>
     <Profiling>false</Profiling>
     <AOTMode>None</AOTMode>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -50,6 +51,7 @@
     <DefineConstants>__UNIFIED__;__MACOS__;</DefineConstants>
     <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
     <AOTMode>None</AOTMode>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -68,6 +70,7 @@
     <UseRefCounting>false</UseRefCounting>
     <Profiling>false</Profiling>
     <AOTMode>None</AOTMode>
+    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/SceneKitReel/SceneKitReelMac/SceneKitReelMac.csproj
+++ b/SceneKitReel/SceneKitReelMac/SceneKitReelMac.csproj
@@ -53,25 +53,6 @@
     <AOTMode>None</AOTMode>
     <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\AppStore</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <LinkMode>SdkOnly</LinkMode>
-    <UseSGen>false</UseSGen>
-    <IncludeMonoRuntime>true</IncludeMonoRuntime>
-    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
-    <CreatePackage>true</CreatePackage>
-    <CodeSigningKey>3rd Party Mac Developer Application</CodeSigningKey>
-    <EnableCodeSigning>true</EnableCodeSigning>
-    <EnablePackageSigning>true</EnablePackageSigning>
-    <UseRefCounting>false</UseRefCounting>
-    <Profiling>false</Profiling>
-    <AOTMode>None</AOTMode>
-    <HttpClientHandler>NSUrlSessionHandler</HttpClientHandler>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />

--- a/SceneKitReel/SceneKitReeliOS/Info.plist
+++ b/SceneKitReel/SceneKitReeliOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>SceneKitReeliOS</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.your-company.SceneKitReeliOS</string>
+	<string>com.xamarin.SceneKitReeliOS</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/SceneKitReel/SceneKitReeliOS/SceneKitReeliOS.csproj
+++ b/SceneKitReel/SceneKitReeliOS/SceneKitReeliOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -25,6 +25,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchUseSGen>true</MtouchUseSGen>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>full</DebugType>
@@ -38,6 +39,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchUseSGen>true</MtouchUseSGen>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,12 +54,11 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
-    <IpaPackageName>
-    </IpaPackageName>
-    <MtouchI18n>
-    </MtouchI18n>
+    <IpaPackageName></IpaPackageName>
+    <MtouchI18n></MtouchI18n>
     <MtouchUseSGen>true</MtouchUseSGen>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>full</DebugType>
@@ -72,6 +73,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchUseSGen>true</MtouchUseSGen>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>full</DebugType>
@@ -87,6 +89,7 @@
     <CodesignKey>iPhone Distribution</CodesignKey>
     <MtouchUseSGen>true</MtouchUseSGen>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
     <DebugType>full</DebugType>
@@ -101,6 +104,7 @@
     <CodesignKey>iPhone Distribution</CodesignKey>
     <MtouchUseSGen>true</MtouchUseSGen>
     <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/SceneKitReel/SceneKitReeliOS/SceneKitReeliOS.csproj
+++ b/SceneKitReel/SceneKitReeliOS/SceneKitReeliOS.csproj
@@ -51,8 +51,10 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
-    <IpaPackageName></IpaPackageName>
-    <MtouchI18n></MtouchI18n>
+    <IpaPackageName>
+    </IpaPackageName>
+    <MtouchI18n>
+    </MtouchI18n>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <IpaPackageName>
     </IpaPackageName>
@@ -68,29 +70,6 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
-    <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\iPhone\Ad-Hoc</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <BuildIpa>true</BuildIpa>
-    <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\iPhone\AppStore</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>


### PR DESCRIPTION
- Pared down build configurations in a few places where there were unnecessarily many
- Updated `CFBundleIdentifier` values to be `com.xamarin.<sample>` in all samples
- Set `HttpClientHandler` and `MtouchHttpClientHandler` to `NSUrlSessionHandler` in all samples
- Made sure that 64-bit architecture is getting built in all places
- Removed some unnecessary build nodes (MtouchUseSGen; MtouchUseRefCounting)

Tested by building all configurations for all samples locally