### PR TITLE
Fixed the crash when metal isn't supported

### DIFF
--- a/MetalKitEssentials/MetalKitEssentials.Shared/MetalKitEssentialsViewController.cs
+++ b/MetalKitEssentials/MetalKitEssentials.Shared/MetalKitEssentialsViewController.cs
@@ -36,7 +36,7 @@ namespace MetalKitEssentials
 		// View Controller.
 		Semaphore inflightSemaphore;
 		int constantDataBufferIndex;
-        bool isMetalSupported;
+        	bool isMetalSupported;
 
 		// Uniforms.
 		Matrix4 projectionMatrix;
@@ -56,8 +56,8 @@ namespace MetalKitEssentials
 			inflightSemaphore = new Semaphore (maxInflightBuffers, maxInflightBuffers);
 
 			SetupMetal ();
-            	if (isMetalSupported)
-            	{
+            		if (isMetalSupported)
+            		{
 				SetupView ();
 				LoadAssets ();
 				Reshape ();

--- a/MetalKitEssentials/MetalKitEssentials.Shared/MetalKitEssentialsViewController.cs
+++ b/MetalKitEssentials/MetalKitEssentials.Shared/MetalKitEssentialsViewController.cs
@@ -36,7 +36,8 @@ namespace MetalKitEssentials
 		// View Controller.
 		Semaphore inflightSemaphore;
 		int constantDataBufferIndex;
-        
+        bool isMetalSupported;
+
 		// Uniforms.
 		Matrix4 projectionMatrix;
 		Matrix4 viewMatrix;
@@ -55,9 +56,12 @@ namespace MetalKitEssentials
 			inflightSemaphore = new Semaphore (maxInflightBuffers, maxInflightBuffers);
 
 			SetupMetal ();
-			SetupView ();
-			LoadAssets ();
-			Reshape ();
+            if (isMetalSupported)
+            {
+				SetupView ();
+				LoadAssets ();
+				Reshape ();
+			}
 		}
 
 		public void DrawableSizeWillChange (MTKView view, CGSize size)
@@ -124,16 +128,26 @@ namespace MetalKitEssentials
 			commandBuffer.Commit ();
 		}
 
-		void SetupMetal ()
+        void SetupMetal ()
 		{
 			// Set the view to use the default device.
 			device = MTLDevice.SystemDefault;
+			if (device != null)
+			{
+				// mark that metal is supported by this device
+				isMetalSupported = true;
 
-			// Create a new command queue.
-			commandQueue = device.CreateCommandQueue ();
+				// Create a new command queue.
+				commandQueue = device.CreateCommandQueue ();
 
-			// Load all the shader files with a metal file extension in the project.
-			defaultLibrary = device.CreateDefaultLibrary ();
+				// Load all the shader files with a metal file extension in the project.
+				defaultLibrary = device.CreateDefaultLibrary ();
+			}
+			else
+			{
+				// that mean that device doesn't support Metal
+				isMetalSupported = false;
+			}
 		}
 
 		void SetupView ()

--- a/MetalKitEssentials/MetalKitEssentials.Shared/MetalKitEssentialsViewController.cs
+++ b/MetalKitEssentials/MetalKitEssentials.Shared/MetalKitEssentialsViewController.cs
@@ -56,8 +56,8 @@ namespace MetalKitEssentials
 			inflightSemaphore = new Semaphore (maxInflightBuffers, maxInflightBuffers);
 
 			SetupMetal ();
-            if (isMetalSupported)
-            {
+            	if (isMetalSupported)
+            	{
 				SetupView ();
 				LoadAssets ();
 				Reshape ();
@@ -128,7 +128,7 @@ namespace MetalKitEssentials
 			commandBuffer.Commit ();
 		}
 
-        void SetupMetal ()
+        	void SetupMetal ()
 		{
 			// Set the view to use the default device.
 			device = MTLDevice.SystemDefault;

--- a/MetalKitEssentials/MetalKitEssentials.iOS/MetalKitEssentials.iOS.csproj
+++ b/MetalKitEssentials/MetalKitEssentials.iOS/MetalKitEssentials.iOS.csproj
@@ -62,7 +62,6 @@
     <MtouchProfiling>true</MtouchProfiling>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
-    <MtouchUseRefCounting>true</MtouchUseRefCounting>
     <MtouchI18n></MtouchI18n>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>


### PR DESCRIPTION
The `MetalKitEssentials` fails on ElCapitan machine because it doesn't support Metal. I added a workaround to fix the crash.

```
Unhandled Exception:
System.NullReferenceException: Object reference not set to an instance of an object
  at MetalKitEssentials.MetalKitEssentialsViewController.SetupMetal () [0x0000c] in /Users/builder/agent/_work/r16/a/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Shared/MetalKitEssentialsViewController.cs:133 
  at MetalKitEssentials.MetalKitEssentialsViewController.ViewDidLoad () [0x0001c] in /Users/builder/agent/_work/r16/a/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Shared/MetalKitEssentialsViewController.cs:57 
--- End of stack trace from previous location where exception was thrown ---
  at (wrapper managed-to-native) AppKit.NSApplication.NSApplicationMain(int,string[])
  at AppKit.NSApplication.Main (System.String[] args) [0x00040] in /Library/Frameworks/Xamarin.Mac.framework/Versions/4.5.0.386/src/Xamarin.Mac/AppKit/NSApplication.cs:100 
  at MetalKitEssentials.Mac.MainClass.Main (System.String[] args) [0x00007] in /Users/builder/agent/_work/r16/a/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/Main.cs:9 
[ERROR] FATAL UNHANDLED EXCEPTION: System.NullReferenceException: Object reference not set to an instance of an object
  at MetalKitEssentials.MetalKitEssentialsViewController.SetupMetal () [0x0000c] in /Users/builder/agent/_work/r16/a/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Shared/MetalKitEssentialsViewController.cs:133 
  at MetalKitEssentials.MetalKitEssentialsViewController.ViewDidLoad () [0x0001c] in /Users/builder/agent/_work/r16/a/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Shared/MetalKitEssentialsViewController.cs:57 
--- End of stack trace from previous location where exception was thrown ---
  at (wrapper managed-to-native) AppKit.NSApplication.NSApplicationMain(int,string[])
  at AppKit.NSApplication.Main (System.String[] args) [0x00040] in /Library/Frameworks/Xamarin.Mac.framework/Versions/4.5.0.386/src/Xamarin.Mac/AppKit/NSApplication.cs:100 
  at MetalKitEssentials.Mac.MainClass.Main (System.String[] args) [0x00007] in /Users/builder/agent/_work/r16/a/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.Mac/Main.cs:9 
```