### PR TITLE
[MetalKitEssentials] Fix solution configurations to not freak out nuget.

### DIFF
--- a/MetalKitEssentials/MetalKitEssentials.sln
+++ b/MetalKitEssentials/MetalKitEssentials.sln
@@ -9,8 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetalKitEssentials.Mac", "M
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-        Debug = Debug
-        Release = Release
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 		Debug|iPhoneSimulator = Debug|iPhoneSimulator
 		Release|iPhone = Release|iPhone
 		Release|iPhoneSimulator = Release|iPhoneSimulator
@@ -25,9 +25,9 @@ Global
 		{EADF2F60-DC7B-4D90-A113-E43E061AAB78}.Release|iPhone.Build.0 = Release|iPhone
 		{EADF2F60-DC7B-4D90-A113-E43E061AAB78}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
 		{EADF2F60-DC7B-4D90-A113-E43E061AAB78}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
-        {3348FFBF-1401-4E10-AA27-718440E25D3F}.Debug.ActiveCfg = Debug
-        {3348FFBF-1401-4E10-AA27-718440E25D3F}.Debug.Build.0 = Debug
-        {3348FFBF-1401-4E10-AA27-718440E25D3F}.Release.ActiveCfg = Release
-        {3348FFBF-1401-4E10-AA27-718440E25D3F}.Release.Build.0 = Release
+		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3348FFBF-1401-4E10-AA27-718440E25D3F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Fixes:

    $ nuget restore
    NuGet Version: 4.8.1.5435
    MSBuild auto-detection: using msbuild version '15.0' from '/Library/Frameworks/Mono.framework/Versions/5.20.0/lib/mono/msbuild/15.0/bin'. Use option -MSBuildVersion to force nuget to use a specific version of MSBuild.
    Error parsing solution file at [...]/mac-ios-samples/MetalKitEssentials/MetalKitEssentials.sln: Exception has been thrown by the target of an invocation.  Error parsing the solution configuration section in solution file. The entry "Debug = Debug" is invalid.  [...]//mac-ios-samples/MetalKitEssentials/MetalKitEssentials.sln
    NuGet.CommandLine.CommandLineException: Error parsing solution file at [...]//mac-ios-samples/MetalKitEssentials/MetalKitEssentials.sln: Exception has been thrown by the target of an invocation.  Error parsing the solution configuration section in solution file. The entry "Debug = Debug" is invalid.  [...]//mac-ios-samples/MetalKitEssentials/MetalKitEssentials.sln
      at NuGet.CommandLine.MsBuildUtility.GetAllProjectFileNamesWithMsBuild (System.String solutionFile, System.String msbuildPath) [0x000a1] in <d8d2a01d48e14f94a3b2632e34b082e7>:0
      at NuGet.CommandLine.MsBuildUtility.GetAllProjectFileNames (System.String solutionFile, System.String msbuildPath) [0x00021] in <d8d2a01d48e14f94a3b2632e34b082e7>:0
      at NuGet.CommandLine.RestoreCommand.ProcessSolutionFile (System.String solutionFileFullPath, NuGet.CommandLine.RestoreCommand+PackageRestoreInputs restoreInputs) [0x00056] in <d8d2a01d48e14f94a3b2632e34b082e7>:0
      at NuGet.CommandLine.RestoreCommand.GetInputsFromFile (System.String projectFilePath, NuGet.CommandLine.RestoreCommand+PackageRestoreInputs packageRestoreInputs) [0x00072] in <d8d2a01d48e14f94a3b2632e34b082e7>:0
      at NuGet.CommandLine.RestoreCommand.DetermineRestoreInputsAsync () [0x00080] in <d8d2a01d48e14f94a3b2632e34b082e7>:0
      at NuGet.CommandLine.RestoreCommand.ExecuteCommandAsync () [0x000be] in <d8d2a01d48e14f94a3b2632e34b082e7>:0