### PR TITLE
[Adventure] Use a AppStore-distribution certificate for release builds.

### DIFF
--- a/Adventure/AdventureMac/AdventureMac.csproj
+++ b/Adventure/AdventureMac/AdventureMac.csproj
@@ -41,7 +41,7 @@
     <UseSGen>false</UseSGen>
     <IncludeMonoRuntime>true</IncludeMonoRuntime>
     <EnablePackageSigning>false</EnablePackageSigning>
-    <CodeSigningKey>Developer ID Application</CodeSigningKey>
+    <CodeSigningKey>3rd Party Mac Developer Application</CodeSigningKey>
     <EnableCodeSigning>true</EnableCodeSigning>
     <CreatePackage>true</CreatePackage>
     <UseRefCounting>false</UseRefCounting>


### PR DESCRIPTION
Because that's what we have available on our bots for testing.